### PR TITLE
Fixed mp_limb_t and mp_limb_signed_t types, reimplemented mpz_t converter

### DIFF
--- a/src/gmp/header.nim
+++ b/src/gmp/header.nim
@@ -15,8 +15,8 @@ type
     mp_lc* {.importc: "_mp_lc".}: pointer
   
   # should check limb sizes / import them directly?
-  mp_limb_t* {.importc: "mp_limb_t", nodecl.} = culong
-  mp_limb_signed_t* {.importc: "mp_limb_signed_t", nodecl.} = clong
+  mp_limb_t* {.importc: "mp_limb_t", nodecl.} = uint
+  mp_limb_signed_t* {.importc: "mp_limb_signed_t", nodecl.} = int
   mp_bitcnt_t* {.importc: "mp_bitcnt_t", nodecl.} = culong
   mm_mpz_struct* {.byref, importc: "__mpz_struct", header: "<gmp.h>".} = object 
     mp_alloc* {.importc: "_mp_alloc".}: cint

--- a/src/gmp/pure.nim
+++ b/src/gmp/pure.nim
@@ -19,8 +19,8 @@ type
   mm_gmp_randstate_algdata* {.pure.} = object  {.union.}
     mp_lc*: pointer
 
-  mp_limb_t* = culong
-  mp_limb_signed_t* = clong
+  mp_limb_t* = uint
+  mp_limb_signed_t* = int
   mp_bitcnt_t* = culong
   mm_mpz_struct* {.byref, pure.} = object 
     mp_alloc*: cint

--- a/src/gmp/utils.nim
+++ b/src/gmp/utils.nim
@@ -22,13 +22,18 @@ proc init_mpz*(): mpz_t =
 
 #converter toPtr*(a: var mpz_t): ptr mpz_t =
 #  a.addr
-  
+
 proc init_mpz*(enc: string, base: cint = 10): mpz_t =
   if mpz_init_set_str(result,enc, base) != 0:
     raise newException(ValueError,enc & " represents an invalid value") 
-    
-converter convert*(a: clong): mpz_t =
-  mpz_init_set_si(result,a)
+
+converter convert*(a: int): mpz_t =
+  when sizeof(clong) != sizeof(int): # LLP64 programming model
+    mpz_init(result)
+    if a < 0: result.mp_size = -1 else: result.mp_size = 1
+    result.mp_d[] = a
+  else:
+    mpz_init_set_si(result, a)
 
 converter convert*(a: mpf_t): mpz_t =
   result = init_mpz()


### PR DESCRIPTION
Hi!
`mp_limb_t` and `mp_limb_signed_t` types should have the size of a pointer.
On the other hand, I fixed the mpz_t converter so it is portable across 32 and 64 bit architectures using any programming model in an efficient way.
