### PR TITLE
fix .nimble file

### DIFF
--- a/gmp.nimble
+++ b/gmp.nimble
@@ -1,5 +1,5 @@
 [Package]
-name          = "nim-gmp"
+name          = "gmp"
 version       = "0.2.4"
 author        = "Will Szumski"
 description   = "Wrapper for the GNU Multiple Precision Arithmetic Library (GMP)"


### PR DESCRIPTION
The current version of nimble requires that the name field in the.nimble file match the file name of the .nimble file.  Currently using nimble to install the package fails. This fixes it.
